### PR TITLE
Set number of dataloader workers to a sane default

### DIFF
--- a/src/pytorch_fid/fid_score.py
+++ b/src/pytorch_fid/fid_score.py
@@ -271,7 +271,7 @@ def main():
     fid_value = calculate_fid_given_paths(args.path,
                                           args.batch_size,
                                           device,
-                                          args.dims
+                                          args.dims,
                                           args.num_workers)
     print('FID: ', fid_value)
 

--- a/src/pytorch_fid/fid_score.py
+++ b/src/pytorch_fid/fid_score.py
@@ -56,7 +56,7 @@ parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
 parser.add_argument('--batch-size', type=int, default=50,
                     help='Batch size to use')
 parser.add_argument('--num-workers', type=int, default=8,
-                    help='Batch size to use')
+                    help='Number of processes to use for data loading')
 parser.add_argument('--device', type=str, default=None,
                     help='Device to use. Like cuda, cuda:0 or cpu')
 parser.add_argument('--dims', type=int, default=2048,
@@ -227,7 +227,7 @@ def calculate_activation_statistics(files, model, batch_size=50, dims=2048,
     return mu, sigma
 
 
-def compute_statistics_of_path(path, model, batch_size, dims, device, num_workers):
+def compute_statistics_of_path(path, model, batch_size, dims, device, num_workers=8):
     if path.endswith('.npz'):
         with np.load(path) as f:
             m, s = f['mu'][:], f['sigma'][:]
@@ -241,7 +241,7 @@ def compute_statistics_of_path(path, model, batch_size, dims, device, num_worker
     return m, s
 
 
-def calculate_fid_given_paths(paths, batch_size, device, dims, num_workers):
+def calculate_fid_given_paths(paths, batch_size, device, dims, num_workers=8):
     """Calculates the FID of two paths"""
     for p in paths:
         if not os.path.exists(p):


### PR DESCRIPTION
The prior default was the number of available CPUs which leads to issues
for systems with a large number of CPUs (e.g. DGX).

This change introduces an optional argument "--num-workers"
which defaults to 8.

Signed-off-by: Steven Lang <steven.lang.mz@gmail.com>