### PR TITLE
Implement Inception Score

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ The choices are:
 - 768:  pre-aux classifier features
 - 2048: final average pooling features (this is the default)
 
+### Compute inception score
+Besides FID, [Inception score](https://arxiv.org/abs/1606.03498) is also a standard measurement for many GANs papers. To compute IS of a dataset:
+
+```
+python -m pytorch_fid path/to/dataset None --inception-score 
+```
+
+However, the IS metric has a lot of weaknesses that are clarified [here](https://arxiv.org/abs/1801.01973).
+
 ## Citing
 
 If you use this repository in your research, consider citing it using the following Bibtex entry:

--- a/src/pytorch_fid/test.py
+++ b/src/pytorch_fid/test.py
@@ -1,0 +1,68 @@
+import numpy as np
+import torch
+import torchvision.transforms as TF
+
+from tqdm import tqdm
+
+def calculate_inception_score(data, batch_size, device, num_workers=1, splits=10):
+    '''
+    Here, decide to use the inceptionv3 on Pytorch
+    '''
+    from torchvision.models.inception import inception_v3
+    import torch.nn.functional as F
+
+    model = inception_v3(pretrained=True, transform_input=False)
+    model.to(device)
+    model.eval()
+    # dataset = ImagePathDataset(files, transforms=TF.ToTensor())
+    dataloader = torch.utils.data.DataLoader(data,
+                                            batch_size = batch_size,
+                                            shuffle=False,
+                                            drop_last=False,
+                                            num_workers=num_workers)
+    # dataloader = torch.utils.data.DataLoader(dataset,
+    #                                          batch_size=batch_size,
+    #                                          shuffle=False,
+    #                                          drop_last=False,
+    #                                          num_workers=num_workers)
+
+    pred_arr = np.empty((len(data), 1000))
+
+    start_idx = 0
+
+    for (batch,_) in tqdm(dataloader):
+        batch = batch.to(device)
+        
+        batch = F.interpolate(batch,
+                            size=(299, 299),
+                            mode='bilinear',
+                            align_corners=False)
+        batch = batch*2 - 1
+
+        with torch.no_grad():
+            pred = F.softmax(model(batch), dim = 1).cpu().numpy()
+
+        pred_arr[start_idx:start_idx + pred.shape[0]] = pred
+        start_idx = start_idx + pred.shape[0]
+
+    scores = []
+    for i in range(splits):
+        part = pred_arr[(i*pred_arr.shape[0]//splits):((i+1)*pred_arr.shape[0]//splits), :]
+        kl = part * (np.log(part) - np.log(np.expand_dims(np.mean(part, 0), 0))) # kl divergence       
+        kl = np.mean(np.sum(kl, 1)) # can be modify with scipy.stats.entropy
+        scores.append(np.exp(kl))
+    return np.mean(scores), np.std(scores)
+
+if __name__ == '__main__':   
+    from torchvision.datasets import CIFAR10
+    data = CIFAR10('D:/DATA/CIFAR-10/old-cifar-10-batches-py/torchvision/', train=True, transform=TF.ToTensor(), download=True)
+    
+
+    device = torch.device('cuda' if (torch.cuda.is_available()) else 'cpu')
+
+    m, s = calculate_inception_score(data=data,
+                                    batch_size=50,
+                                    device=device,
+                                    num_workers=0,
+                                    splits=10)
+    print(f'Inception score: {round(m,4)} +- {round(s,4)}')


### PR DESCRIPTION
Hi,
Recently, there is some research still evaluating their model by Inception Score, and issue #20 also mentions it. I create a pull request to add the implementation of computing the inception score.

### Change
+ implement the `calculate_inception_score` . In this implementation, I used the weight of Inception-V3 from the Pytorch team to predict the probs of images  (to validate my implementation in the test phase).
+ add --inception-score as `store_true` argument and --splits with default is 10 (just like the original code).

### Test
I tested it with CIFAR-10 (`pytorch-fid/src/pytorch-fid/test.py`), in [this paper](https://arxiv.org/abs/1801.01973), the mean and std of CIFAR-10 are 9.737 and 0.1489. In this PR, the test result return inception score 9.6728±0.1499. (the difference may come from Torch or NumPy version).

### Problems
+ While testing, I found out that IS is really hard to use, not only because of the issues from the paper above. Because the predicted results then have to be split into groups, the arrangement of data is also a problem (if  `shuffle=True` in `dataloader`, the result will be different).
+ Different from FID, IS is computed individually for each dataset, so the input only needs one path. The function is taking the first path as input and ignoring the second, I wonder is there any more flexible way to fix this.
