### PR TITLE
Replace deprecated function parameters in torchvision API for Inception model

### DIFF
--- a/src/pytorch_fid/inception.py
+++ b/src/pytorch_fid/inception.py
@@ -79,7 +79,7 @@ class InceptionV3(nn.Module):
         if use_fid_inception:
             inception = fid_inception_v3()
         else:
-            inception = _inception_v3(pretrained=True)
+            inception = _inception_v3(weights='DEFAULT')
 
         # Block 0: input to maxpool1
         block0 = [
@@ -192,7 +192,7 @@ def fid_inception_v3():
     """
     inception = _inception_v3(num_classes=1008,
                               aux_logits=False,
-                              pretrained=False)
+                              weights=None)
     inception.Mixed_5b = FIDInceptionA(192, pool_features=32)
     inception.Mixed_5c = FIDInceptionA(256, pool_features=64)
     inception.Mixed_5d = FIDInceptionA(288, pool_features=64)


### PR DESCRIPTION
PyTorch changed the model zoo API, see https://pytorch.org/vision/main/models/generated/torchvision.models.inception_v3.html

The following equivalences hold:
```
pretrained=False -> weights=None
pretrained=True -> weights='DEFAULT'
```

The old code produces the following warnings
```
torchvision/models/_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and may be removed in the future, please use 'weights' instead.
  warnings.warn(
torchvision/models/_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing `weights=None`.
  warnings.warn(msg)
```
