### PR TITLE
Fix description

### DIFF
--- a/src/pytorch_fid/fid_score.py
+++ b/src/pytorch_fid/fid_score.py
@@ -266,7 +266,7 @@ def calculate_fid_given_paths(paths, batch_size, device, dims, num_workers=1):
 
 
 def save_fid_stats(paths, batch_size, device, dims, num_workers=1):
-    """Calculates the FID of two paths"""
+    """Saves FID statistics of one path"""
     if not os.path.exists(paths[0]):
         raise RuntimeError('Invalid path: %s' % paths[0])
 


### PR DESCRIPTION
Nano-fix: the docstrings of `save_fid_stats` mentioned computing the FID of two paths (it was probably copy-pasted from the above function).